### PR TITLE
Changes to documentation to replace bits involving mbox

### DIFF
--- a/BOMD.rst
+++ b/BOMD.rst
@@ -422,8 +422,8 @@ both the density kernel and the support functions. Here below, we
 briefly review various algorithms that allows to initialise the density
 kernel and NGWFs by extrapolation from previous time steps.
 
-Hereafter, :math:`\chi{^{\mbox{\tiny{init}}}}_i` and
-:math:`\chi{^{\mbox{\tiny{scf}}}}_i` are used to represent respectively
+Hereafter, :math:`\chi^{\text{init}}_i` and
+:math:`\chi^{\text{scf}}_i` are used to represent respectively
 the initial guess and SCF solution for either the density kernel or a
 given NGWF at time :math:`t=i\Delta t`.
 
@@ -435,7 +435,7 @@ One-dimensional linear extrapolation
       .. math::
 	 :label: linxtpol1
 
-         \chi{^{\mbox{\tiny{init}}}}_{(i+1)} = 2\chi{^{\mbox{\tiny{scf}}}}_{i}-\chi{^{\mbox{\tiny{scf}}}}_{(i-1)}.
+         \chi^{\text{init}}_{(i+1)} = 2\chi^{\text{scf}}_{i}-\chi^{\text{scf}}_{(i-1)}.
 
 Multi-dimensional linear extrapolation
     
@@ -452,7 +452,7 @@ Multi-dimensional linear extrapolation
       .. math::
 	 :label: multixtpol1
 
-         \chi{^{\mbox{\tiny{init}}}}_{(i+1)} = \chi{^{\mbox{\tiny{scf}}}}_{i} + \sum_{n=0}^{N} c_n \left(\chi{^{\mbox{\tiny{scf}}}}_{(i-n)}  - \chi{^{\mbox{\tiny{scf}}}}_{(i-(n+1))} \right)
+         \chi^{\text{init}}_{(i+1)} = \chi^{\text{scf}}_{i} + \sum_{n=0}^{N} c_n \left(\chi^{\text{scf}}_{(i-n)}  - \chi^{\text{scf}}_{(i-(n+1))} \right)
 
       where the :math:`N+1` coefficients :math:`\{c_n\}` are chosen by
       minimizing the norm,
@@ -535,7 +535,7 @@ Projection of the density kernel
       to adapt it to the new support functions is to project the density
       kernel onto the extrapolated NGWFs. This transformation reads,
 
-      .. math:: \mathbf{K}{^{\mbox{\tiny{init}}}}_{(i+1)} = \left(\mathbf{S}{^{\mbox{\tiny{init}}}}_{i+1}\right)^{-1} \mathbf{T}_{(i+1),i} \ \mathbf{K}{^{\mbox{\tiny{scf}}}}_{i} \ \mathbf{T}_{i,(i+1)} \left(\mathbf{S}{^{\mbox{\tiny{init}}}}_{i+1}\right)^{-1} \ ,
+      .. math:: \mathbf{K}^{\text{init}}_{(i+1)} = \left(\mathbf{S}^{\text{init}}_{i+1}\right)^{-1} \mathbf{T}_{(i+1),i} \ \mathbf{K}^{\text{scf}}_{i} \ \mathbf{T}_{i,(i+1)} \left(\mathbf{S}^{\text{init}}_{i+1}\right)^{-1} \ ,
 
       where :math:`\mathbf{K}_i` and :math:`\mathbf{S}_i` stand for the
       density kernel and overlap matrix at MD step :math:`i`; and
@@ -555,11 +555,11 @@ Christoffel correction to the density kernel
       symbols should be accounted for in the transformation of the
       density kernel. The correction to the density kernel then reads,
 
-      .. math:: \Delta \mathbf{K}{^{\mbox{\tiny{init}}}}_{(i+1)} = -\left(\mathbf{S}{^{\mbox{\tiny{scf}}}}_{i} \right)^{-1}\  \mathbf{D}_{(i+1),i}\ \mathbf{K}_{i} \ - \mathbf{K}_{i}\ \mathbf{D}_{i,(i+1)}\ \left(\mathbf{S}{^{\mbox{\tiny{scf}}}}_{i} \right)^{-1}
+      .. math:: \Delta \mathbf{K}^{\text{init}}_{(i+1)} = -\left(\mathbf{S}^{\text{scf}}_{i} \right)^{-1}\  \mathbf{D}_{(i+1),i}\ \mathbf{K}_{i} \ - \mathbf{K}_{i}\ \mathbf{D}_{i,(i+1)}\ \left(\mathbf{S}^{\text{scf}}_{i} \right)^{-1}
 
       with
 
-      .. math:: \left(\mathbf{D}_{(i+1),i}\right)_{\alpha \beta} = \left \langle (\phi{^{\mbox{\tiny{init}}}}_{(i+1)})_{\alpha} - (\phi{^{\mbox{\tiny{scf}}}}_{i})_{\alpha} \ \bigg| \  (\phi{^{\mbox{\tiny{scf}}}}_{i})_{\beta} \right \rangle \ .
+      .. math:: \left(\mathbf{D}_{(i+1),i}\right)_{\alpha \beta} = \left \langle (\phi^{\text{init}}_{(i+1)})_{\alpha} - (\phi^{\text{scf}}_{i})_{\alpha} \ \bigg| \  (\phi^{\text{scf}}_{i})_{\beta} \right \rangle \ .
 
 Extended Lagrangian propagation of density kernel schemes
 ---------------------------------------------------------
@@ -609,7 +609,7 @@ Extended Lagrangian with dissipation, dEL/SCF
       .. math::
 
          \begin{aligned}
-         \mathbf{P}_{i+1} &= 2\mathbf{P}_{i} - \mathbf{P}_{i - 1} + \kappa[(\mathbf{KS}{^{\mbox{\tiny{scf}}}})_i - \mathbf{P}_{i}] \nonumber \\
+         \mathbf{P}_{i+1} &= 2\mathbf{P}_{i} - \mathbf{P}_{i - 1} + \kappa[(\mathbf{KS}^{\text{scf}})_i - \mathbf{P}_{i}] \nonumber \\
           &&+ \,\alpha\sum_{m=0}^M c_m \mathbf{P}_{i-m}. \end{aligned}
 
       where :math:`\kappa`, :math:`\alpha` and :math:`c_m`\ ’s are
@@ -617,7 +617,7 @@ Extended Lagrangian with dissipation, dEL/SCF
       Ref. [Niklasson2009]_. The initial guess for the
       density kernel is given by
 
-      .. math:: \mathbf{K}{^{\mbox{\tiny{init}}}}_{i+1} = \mbox{sym}(\mathbf{PS}^{-1}_{i+1}) = \frac{1}{2}[(\mathbf{PS}^{-1})_{i+1} + (\mathbf{S}^{-1}\mathbf{P})_{i+1}]
+      .. math:: \mathbf{K}^{\text{init}}_{i+1} = \mbox{sym}(\mathbf{PS}^{-1}_{i+1}) = \frac{1}{2}[(\mathbf{PS}^{-1})_{i+1} + (\mathbf{S}^{-1}\mathbf{P})_{i+1}]
 
       The problem with the above mentioned scheme lays in the use of a
       dissipative term that unavoidably breaks the time-reversibility,
@@ -640,17 +640,17 @@ Extended Lagrangian with thermostat, inertial iEL/SCF
       .. math::
 
          \begin{aligned}
-         \mathbf{P}_{i + 1} &= \mathbf{P}_{i} + \dot{\mathbf{P}}_{i}\Delta t + \omega^2{\Delta t}^2[(\mathbf{KS}){^{\mbox{\tiny{scf}}}}_i - \mathbf{P}_{i}]  \\
+         \mathbf{P}_{i + 1} &= \mathbf{P}_{i} + \dot{\mathbf{P}}_{i}\Delta t + \omega^2{\Delta t}^2[(\mathbf{KS})^{\text{scf}}_i - \mathbf{P}_{i}]  \\
          \dot{\mathbf{P}}_{i + 1} &= \gamma_i\dot{\widetilde{\mathbf{P}}}_{i + 1} \nonumber \\ 
-          &= \gamma_i \{ \dot{\mathbf{P}}_{i} + \omega^2{\Delta t}/2[((\mathbf{KS}){^{\mbox{\tiny{scf}}}}_{i+1} - \mathbf{P}_{i + 1}) +  \nonumber \\
-          &  ((\mathbf{KS}){^{\mbox{\tiny{scf}}}}_i - \mathbf{P}_i)] \} 
+          &= \gamma_i \{ \dot{\mathbf{P}}_{i} + \omega^2{\Delta t}/2[((\mathbf{KS})^{\text{scf}}_{i+1} - \mathbf{P}_{i + 1}) +  \nonumber \\
+          &  ((\mathbf{KS})^{\text{scf}}_i - \mathbf{P}_i)] \} 
           \end{aligned}
 
       with :math:`\gamma_i` given by
 
-      .. math:: \gamma_i = \sqrt{1+\frac{\tau}{\Delta t}\left(\frac{T{_{\mbox{\tiny{K}}}}}{ \langle\dot{\mathbf{P}_{i}}^2}\rangle - 1\right)}
+      .. math:: \gamma_i = \sqrt{1+\frac{\tau}{\Delta t}\left(\frac{T_{\text{K}}}{ \langle\dot{\mathbf{P}_{i}}^2}\rangle - 1\right)}
 
-      where :math:`T{_{\mbox{\tiny{K}}}}` is the target temperature,
+      where :math:`T_{\text{K}}` is the target temperature,
       :math:`\tau` is the characteristic time of the thermostat, and
       :math:`\langle\dot{\mathbf{P}_{i}}^2\rangle` is the instantaneous
       temperature of the auxiliary degrees of freedom. The key parameter

--- a/hfx.rst
+++ b/hfx.rst
@@ -97,7 +97,7 @@ possible by expressing metric matrix elements for each atom pair in a
 vector between atomic centres and with a set of SWs aligned in this
 coordinate system. When expressed in spherical polar coordinates, the
 1-D integration (over the azimuthal angle, :math:`\phi`) is simple to
-evaluate analytically. The integration over :math:`(r,\theta)` can be
+evaluate analytically. The 2-D integration over :math:`(r,\theta)` can be
 performed by the same approach used in the 3Dc method, i.e. evaluating
 integrals over piecewise expansions of the :math:`(r,\theta)`-dependent
 parts of the SWs and SWpots in Chebyshev polynomials.
@@ -134,7 +134,7 @@ use it later to tell HFx or DMA which SWRI to use (as you can have more
 than one SWRI).
 
 [lmax] :math:`l_{\textrm{max}}` is the maximum angular momentum in the
-SW basis. Supported values are 0 (s-like SWs only), 1 (s- and SWs),
+SW basis. Supported values are 0 (s-like SWs only), 1 (s- and p-like SWs),
 2 (s-, p- and d-like SWs), 3 (s-, p-, d- and f-like SWs) and 4 (you get
 the idea). For HFx choose 2 for a crude calculation, 3 for good quality,
 and 4 for extreme quality. 0 and 1 will likely be too crude to fully
@@ -575,7 +575,7 @@ DMA
 ===
 
 DMA (Distributed Multipole Analysis) is a technique for partitioning
-charge density into single 10000 atom contributions and finding a set of
+charge density into single-atom contributions and finding a set of
 point multipoles that most accurately represent this charge density. The
 point multipoles are usually, although not universally, atom-centered –
 this is the case in ONETEP. DMA was proposed by Rein
@@ -604,7 +604,7 @@ Apart from calculating electronic multipoles, ONETEP's DMA also
 calculates total (electronic + ionic core) atom-centered multipoles.
 Also calculated are the total multipoles of the system (e.g.. the
 molecular dipole or quadrupole), suitably averaged over all the atoms
-that were part of the SWRI. For non 10000 neutral molecules the value of
+that were part of the SWRI. For non-neutral molecules the value of
 the dipole depends on the point where it is calculated (similarly for
 higher multipoles), and so the total multipoles are calculated *at a
 reference point* of your choosing.
@@ -723,7 +723,7 @@ on by default), but care must be taken when using it with polemb-DMA
 limitations arise. (1) In polemb-DMA the DMA multipoles enter LNV and
 NGWF gradient expressions. The quantity
 :math:`\textrm{Tr}\left[\mathbb{KS}\right]` is not strictly a constant,
-and has non 10000 zero DKN and NGWF derivatives, leading to additional
+and has non-zero DKN and NGWF derivatives, leading to additional
 terms in LNV and NGWF gradients when charge-scaling is used. These extra
 terms have been implemented for LNV gradients, but *not* for NGWF
 gradients, where they become really hairy (these are under development).
@@ -751,7 +751,7 @@ polemb-DMA.
 (in bohr) at which total DMA multipoles are calculated. This is mostly
 useful if your system (strictly speaking: your DMA subsystem) is not
 charge-neutral and you are interested in the value of the total dipole.
-When the system is non 10000 neutral, the total dipole is not
+When the system is non-neutral, the total dipole is not
 translation invariant, and a reference point for calculating it needs to
 be specified. This keyword specifies this reference. Also note that when
 a simcell full-density polarisation calculation is performed (via

--- a/implicit_solvation_v3.rst
+++ b/implicit_solvation_v3.rst
@@ -49,7 +49,7 @@ MPSM offers a very accurate treatment of the polar (electrostatic)
 solvation contribution, and a rather simple, yet still accurate,
 treatment of the apolar terms: cavitation, dispersion and repulsion.
 MPSM is based on the Fattebert and Gygi model (later extended by
-Scherlis) [Scherlis2006]_.
+Scherlis *et al.*) [Scherlis2006]_.
 
 Two other models are available – Fisicaro’s soft-sphere model (SSM)
 [Fisicaro2017]_, and Andreussi’s Self-Consistent Continuum
@@ -552,7 +552,7 @@ Manual solvation and restarts
 Occasionally you might want to run a calculation in solvent without
 automatically running a calculation in vacuum first. Perhaps you already
 have the calculation in vacuum and you prefer to manually restart it in
-solvent. This is known as “manual solvation”. To activate it, use (the
+solvent. This is known as “manual solvation”. To activate it, use ``is_implicit_solvent T`` (the
 default is ``F``), and make sure to have ``is_auto_solvation F`` (which
 is the default).
 
@@ -733,7 +733,7 @@ The key takeaway message here is that you need to use smeared ions in
 **both** the in-vacuum calculation and the in-solvent calculation to
 ensure the energy expressions are comparable. To do that, add
 ``is_smeared_ion_rep T`` to your input file(s). If you forget about this
-in a solvation calculation () or if you do auto solvation
+in a solvation calculation (``is_implicit_solvent T``) or if you do auto solvation
 (``is_auto_solvation T``) it will be added automatically for you, but a
 warning will be produced. However, if you run manual solvation, you need
 to remember to include ``is_smeared_ion_rep T`` in the in-vacuum

--- a/starting_with_onetep.rst
+++ b/starting_with_onetep.rst
@@ -85,12 +85,12 @@ Creating input files
 
 Go to the ONETEP website, `onetep.org <onetep.org>`__. There, under *Resources*
 you will find the *Tutorials* section, which introduces running various kinds of
-onetep calculations. Take a look at some of the input files at the
-bottom of the page. Input files in onetep have the ``.dat`` file
+ONETEP calculations. Take a look at some of the input files at the
+bottom of the page. Input files in ONETEP have the ``.dat`` file
 extension. Should any files get downloaded having a ``.txt`` extension,
 you will need to rename them to end with ``.dat``.
 
-Input files contain keywords, instructing onetep on what calculations to
+Input files contain keywords, instructing ONETEP on what calculations to
 run, and to set the parameters needed to run them. Check out the
 keywords on the webpage
 `onetep.org/Main/Keywords <onetep.org/Main/Keywords>`__ to see what they
@@ -109,7 +109,7 @@ for specifying coordinates.
 
 Some of the important keywords to get started are:
 
--  ``task`` – to choose what main calculation you would like onetep to
+-  ``task`` – to choose what main calculation you would like ONETEP to
    perform, e.g. a single point energy calculation or geometry
    optimisation. You can run a properties calculation this way, using
    output files generated from a single point energy calculation or
@@ -149,7 +149,7 @@ use:
 ``C C 6 4 8.0``
 
 The ``species_pot`` block specifies the location of the pseudopotential
-used for each element of the system. The standard onetep norm-conserving
+used for each element of the system. The standard ONETEP norm-conserving
 pseudopotentials (``.recpot`` files) exclude core electrons. Core
 electrons are included in ``.paw`` files. Some of these can be found in
 your repository’s ``pseudo`` directory. A complete database of all
@@ -184,7 +184,7 @@ computer, or at a high-performance computing (HPC) facility. This is
 termed *parallel operation*. There are two main modes of parallel
 operation – *distributed-memory* computing (sometimes termed simply
 *parallelism*), and *shared-memory* computing (sometimes termed
-*concurrency*). onetep combines both of them, so it will be crucial to
+*concurrency*). ONETEP combines both of them, so it will be crucial to
 understand how they work.
 
 Distributed-memory parallelism (MPI)
@@ -204,8 +204,8 @@ their chunks. Yes, even when they are on the same machine.
 
 The problem they work on has to be somehow subdivided between them –
 this is known as *parallel decomposition*. One common way of doing that
-– and one that onetep employs – is *data decomposition*, where it’s the
-data in the problem that is subdivided across processes. In onetep the
+– and one that ONETEP employs – is *data decomposition*, where it’s the
+data in the problem that is subdivided across processes. In ONETEP the
 grids on which quantities like electronic density or external potential
 are calculated are divided across processes, with each process “owning”
 a slab of the grid. Similarly, the atoms in the system are divided
@@ -214,9 +214,9 @@ these concepts are illustrated in :numref:`MPI`.
 
 .. _MPI:
 .. figure:: starting_with_onetep_fig1.png
-   :alt: Illustration of parallel data decomposition in onetep. Figure borrowed from J. Chem. Phys. \ **122**, 084119 (2005), https://doi.org/10.1063/1.1839852, which you are well-advised to read.
+   :alt: Illustration of parallel data decomposition in ONETEP. Figure borrowed from J. Chem. Phys. \ **122**, 084119 (2005), https://doi.org/10.1063/1.1839852, which you are well-advised to read.
 
-   Illustration of parallel data decomposition in onetep. Figure borrowed from J. Chem. Phys. \ **122**, 084119 (2005), https://doi.org/10.1063/1.1839852, which you are well-advised to read.
+   Illustration of parallel data decomposition in ONETEP. Figure borrowed from J. Chem. Phys. \ **122**, 084119 (2005), https://doi.org/10.1063/1.1839852, which you are well-advised to read.
 
 From the point of view of the operating system, the processes running on
 a machine are separate entities (see :numref:`processes`), and
@@ -229,9 +229,9 @@ Message Passing Interface (MPI). This is why we often call the processes
 
 .. _processes:
 .. figure:: starting_with_onetep_fig2.png
-   :alt: Four onetep processes running on one machine, each utilising 100% of a CPU core and 0.4% of available memory.
+   :alt: Four ONETEP processes running on one machine, each utilising 100% of a CPU core and 0.4% of available memory.
 
-   Four onetep processes running on one machine, each utilising 100% of a CPU core and 0.4% of available memory.
+   Four ONETEP processes running on one machine, each utilising 100% of a CPU core and 0.4% of available memory.
 
 MPI facilitates starting multiple processes as part of a single
 calculation, which can become slightly tricky when there are multiple
@@ -244,11 +244,11 @@ desktop machine its invocation typically looks like this:
 ``mpirun -np 4 ./onetep_launcher input.dat >input.out 2>input.err``
 
 Here, ``mpirun`` is the name of the command for launching multiple
-processes, asks for four processes, ``onetep_launcher`` is the name of
-the script for launching onetep – it’s the script that will actually be
-run on four CPU cores, and each instance will start one onetep process
+processes, ``-np 4`` asks for four processes, ``onetep_launcher`` is the name of
+the script for launching ONETEP – it’s the script that will actually be
+run on four CPU cores, and each instance will start one ONETEP process
 for you – here we assume it’s in the current directory (``./``),
-``input.dat`` is your onetep input file. Output will be sent
+``input.dat`` is your ONETEP input file. Output will be sent
 (“redirected”) to ``onetep.out``, and error messages (if any), will be
 redirected to ``input.err``. All four processes will be started on the
 same machine.
@@ -260,15 +260,15 @@ number of processes will be automatically inferred by the batch
 
 MPI lets you run your calculation on as many processes as you like –
 even tens of thousands. However, there are practical limitations to how
-far you can go with onetep. Looking at :numref:`MPI` it becomes clear
+far you can go with ONETEP. Looking at :numref:`MPI` it becomes clear
 that you cannot have more MPI processes than atoms – or some processes
 would be left without work to do. In fact this limitation is even
-slightly stricter – to divide work more evenly onetep tries to give each
+slightly stricter – to divide work more evenly ONETEP tries to give each
 processes a similar number of NGWFs, not atoms. For instance, for a
 water molecule run on two processes, it makes sense to assign the O atom
 and its 4 NGWFs to one process, and both H atoms (1 NGWF each) to the
-second process. If you try to run a calculation on on *three* processes,
-it’s very likely that onetep will do the same thing – assign O to one
+second process. If you try to run a calculation on H:sub:`2`O on *three* processes,
+it’s very likely that ONETEP will do the same thing – assign O to one
 processes, both H’s to another process and the third process will wind
 up with no atoms. This will cause the calculation to abort. So, one
 limitation is **you will not be able to use more MPI processes that you
@@ -296,7 +296,7 @@ synchronisation – e.g. so that thread 1 knows thread 2 finished writing
 something to memory and it’s safe to try to read it. These mechanisms
 are described by a standard known as ``OpenMP``, or ``OMP`` for short.
 
-In onetep threads are most conveniently handled using the launcher’s
+In ONETEP threads are most conveniently handled using the launcher’s
 ``-t`` option, which instructs it how many threads each process should
 spawn. For instance the command
 
@@ -306,9 +306,9 @@ runs one process (note the absence of ``mpirun``), which spawns eight
 threads. This is what it looks like to the operating system:
 
 .. figure:: starting_with_onetep_fig3.png
-   :alt: One onetep process that spawned eight threads, running on one machine, utilising almost 800% of a CPU core and 1.3% of available memory – this is for the entire process encompassing eight threads.
+   :alt: One ONETEP process that spawned eight threads, running on one machine, utilising almost 800% of a CPU core and 1.3% of available memory – this is for the entire process encompassing eight threads.
 
-   One onetep process that spawned eight threads, running on one machine, utilising almost 800% of a CPU core and 1.3% of available memory – this is for the entire process encompassing eight threads.
+   One ONETEP process that spawned eight threads, running on one machine, utilising almost 800% of a CPU core and 1.3% of available memory – this is for the entire process encompassing eight threads.
 
 Thread-based processing has a number of limitations. As threads reside
 within a process, you cannot feasibly run more threads than you have CPU
@@ -319,16 +319,16 @@ any advantage, because the additional threads will not have anything to
 work with (fortunately, this does not lead to the calculation aborting,
 only to some threads idling). Even with four threads you will lose some
 efficiency, because some threads will get 3 atoms and some only 2.
-onetep works best with about 4-6 threads, unless you are using
+ONETEP works best with about 4-6 threads, unless you are using
 Hartree-Fock exchange (HFx), which is the most efficient on large thread
 counts.
 
 Threads are easiest to control via ``onetep_launcher``, which you are
-advised to use, but onetep also provides keywords for controlling them
+advised to use, but ONETEP also provides keywords for controlling them
 manually – these are ``threads_max``, ``threads_per_fftbox``,
 ``threads_num_fftboxes``, ``threads_per_cellfft`` and
 ``threads_num_mkl``. Each of these sets the number of threads spawned
-from a single process for some part of onetep\ ’s functionality. This is
+from a single process for some part of ONETEP\ ’s functionality. This is
 advanced stuff and will not be covered in this beginners’ document.
 
 Another point to note is that each thread requires its own *stack* (a
@@ -346,7 +346,7 @@ Hybrid (combined MPI+OMP) parallelism
 
 For anything but the smallest of systems, combining MPI processes with
 OMP threads is the most efficient approach. This is known as *hybrid
-parallelism*. In onetep this is realised simply by combining ``mpirun``
+parallelism*. In ONETEP this is realised simply by combining ``mpirun``
 (or equivalent) with ``onetep_launcher``\ ’s ``-t`` option, like this:
 
 ``mpirun -np 4 ./onetep_launcher -t 8 input.dat >input.out 2>input.err``
@@ -357,7 +357,7 @@ set-up would fully saturate a large, 32-core desktop machine.
 Setting up processes and threads looks slightly different in HPC
 systems, where you need to start them on separate nodes. Your submission
 script (you will find ones for common architectures in the
-``hpc_resources`` directory of your onetep installation) defines all the
+``hpc_resources`` directory of your ONETEP installation) defines all the
 parameters at the top of the script and then accordingly invokes
 ``mpirun`` (or equivalent) and ``onetep_launcher``. Look at the
 beginning of the script to see what I mean.


### PR DESCRIPTION
Changes to documentation to replace bits involving mbox, which had been inadvertently deleted during the transfer from tex to rst.