### PR TITLE
PDOS recommended values 

### DIFF
--- a/ldos_calculations.rst
+++ b/ldos_calculations.rst
@@ -310,6 +310,34 @@ quantum number. This can be achieved by setting ``pdos_sum_mag : F``.
 This will give histogram data for every magnetic quantum number of every
 angular momentum channel of each atom group.
 
+Recommended Settings
+--------------------
+The following table provides a set of recommended settings for calculating the PDOS in ONETEP:
+
+.. list-table::
+   :widths: 8 20 32 20
+   :header-rows: 1
+
+   * - 
+     - Cutoff energy (eV)
+     - NGWF radii (:math:`a_{0}`)
+     - Basis
+   * - Low
+     - 700
+     - 8.0
+     - Pseudo-atomic orbitals
+   * - Medium
+     - 800
+     - 10.0
+     - Pseudo-atomic orbitals
+   * - High
+     - 1200
+     - 13.0
+     - Fully uncontracted spherical waves
+
+These settings were calibrated and tested with platinum nanoparticles, and are a starting 
+point for obtaining reliable PDOS data.
+
 Interpreting Outputs
 --------------------
 

--- a/ldos_calculations.rst
+++ b/ldos_calculations.rst
@@ -6,7 +6,7 @@ Calculating the Local/Partial Density of States and Angular Momentum Projected D
 :Author: Jolyon Aarons, University of Warwick
 
 :Date: June 2019 (Updated by Jolyon Aarons to add angular momentum PDOS information).
-:Date: Originally written by Nicholas D.M. Hine April 2012. 
+:Date: Originally written by Nicholas D.M. Hine April 2012.
 
 What is being calculated?
 =========================
@@ -31,7 +31,7 @@ Therefore, such a diagonalisation remains fast up to quite large system
 sizes, particularly if a parallel eigensolver such as ScaLAPACK is used.
 
 The generalised eigenproblem that needs to be solved to provide the
-eigenvalues and eigenvectors is:\ 
+eigenvalues and eigenvectors is:\
 
 .. math::
    :label: gen_eig_prob
@@ -103,7 +103,7 @@ resolved functions on which to project our NGWFS,
 
 .. math::
    :label: DOS_identity_operator
-	   
+
    D_{l,I}(\epsilon) \approx \sum_n  \delta(\epsilon-\epsilon_n) \sum_{\alpha,l\in I}(M^{\dagger})_n^{\,\,\,\,\alpha} \sum_{m \in l}\langle{\phi_\alpha
    | \chi'_{\alpha l m}}\rangle \sum_{l'm'} \Lambda^{ l m, l'm'} \sum_\beta \left(\langle{ \chi'_{
    l' m'} |\phi_\beta}\rangle M^\beta_{\ \, n}   \, \right),
@@ -241,7 +241,7 @@ specification:
   here for example:
 
 ::
-  
+
    %block species
      Pt Pt 78 9 9.0
      Pt1 Pt 78 9 9.0
@@ -312,14 +312,14 @@ angular momentum channel of each atom group.
 
 Recommended Settings
 --------------------
-The following table provides a set of recommended settings for 
+The following table provides a set of recommended settings for
 calculating the PDOS in ONETEP:
 
 .. list-table::
    :widths: 8 16 16 20
    :header-rows: 1
 
-   * - 
+   * -
      - Cutoff energy (eV)
      - NGWF radii (:math:`a_{0}`)
      - Basis
@@ -336,8 +336,8 @@ calculating the PDOS in ONETEP:
      - 13.0
      - Fully uncontracted spherical waves
 
-These settings were calibrated and tested with platinum nanoparticles 
-and should be considered a starting point for your own calculations.
+These settings were calibrated and tested with platinum nanoparticles
+and can be considered a starting point for your own calculations.
 
 Interpreting Outputs
 --------------------
@@ -349,33 +349,33 @@ input file with 3 ``pdos_groups`` and ``pdos_max_l=2``):
 
 ::
 
-      
+
     ================ Projected Density of States (pDOS) calculation ================
-    
+
     Constructing AM resolved functions  ... done
     Writing NGWF plot files in formats: ...  done
-    
+
     Performing overlap integrals ...  done
-    
+
     Computing pDOS weights ...  done
-    
+
     All bands spilling parameter =   2.14 %
     Occupancy-weighted spilling parameter =   0.30 %
-    
+
      => Outputting data for OptaDOS <=
-    
+
     Writing pDOS weights to file "Pt3O.val_pdos_bin" ... done
-    
+
     Writing band gradients to file "Pt3O.val_dome_bin" ... done
-    
+
     Writing Castep output cell file to "Pt3O-out.cell" ... done
-    
-      => Computing Gaussian smeared pDOS <= 
+
+      => Computing Gaussian smeared pDOS <=
     Writing "Pt3O_PDOS.txt" ...  done
-    
-      => Computing Occupancy-weighted Gaussian smeared pDOS <= 
+
+      => Computing Occupancy-weighted Gaussian smeared pDOS <=
     Writing "Pt3O_occ_PDOS.txt" ...  done
-      => Band centres: 
+      => Band centres:
      S band centre of group 1 from  -24.409 eV upwards:  -10.785237 eV
      P band centre of group 1 from  -24.409 eV upwards:   -6.380437 eV
      D band centre of group 1 from  -25.000 eV upwards:   -1.992329 eV
@@ -385,7 +385,7 @@ input file with 3 ``pdos_groups`` and ``pdos_max_l=2``):
      S band centre of group 3 from  -24.409 eV upwards:  -20.033099 eV
      P band centre of group 3 from  -24.409 eV upwards:   -6.607392 eV
       Band centres done. <=
-      => Integrated number of electrons in each AM band: 
+      => Integrated number of electrons in each AM band:
      S num electrons of group 1 from  -24.409 eV upwards:    3.768881
      P num electrons of group 1 from  -24.409 eV upwards:    5.624424
      D num electrons of group 1 from  -25.000 eV upwards:   26.497489
@@ -425,7 +425,7 @@ Finally ONETEP reports the energy and occupancy weighted averages of the
 PDOS, so called-band centres, useful in catalysis (e.g. the value
 “d-band centre” is a very useful decsriptor about the ability of a metal
 surface to bind atomic oxygen and other types of adsorbates) and the
-integrated number of electrons in each component. The d-band centre is 
+integrated number of electrons in each component. The d-band centre is
 calculated from a threshold, which by default is -15 eV, but this can be
 adjusted using the ``pdos_d_band_threshold`` keyword.
 

--- a/ldos_calculations.rst
+++ b/ldos_calculations.rst
@@ -319,7 +319,7 @@ calculating the PDOS in ONETEP:
    :widths: 8 16 16 20
    :header-rows: 1
 
-   * -
+   * - Accuracy
      - Cutoff energy (eV)
      - NGWF radii (:math:`a_{0}`)
      - Basis
@@ -425,9 +425,9 @@ Finally ONETEP reports the energy and occupancy weighted averages of the
 PDOS, so called-band centres, useful in catalysis (e.g. the value
 “d-band centre” is a very useful decsriptor about the ability of a metal
 surface to bind atomic oxygen and other types of adsorbates) and the
-integrated number of electrons in each component. The d-band centre is
-calculated from a threshold, which by default is -15 eV, but this can be
-adjusted using the ``pdos_d_band_threshold`` keyword.
+integrated number of electrons in each component. The d-band centre and
+number of electrons are calculated from a threshold, which by default is
+-15 eV, but this can be adjusted using the ``pdos_d_band_threshold`` keyword.
 
 [Skylaris2005] C.-K. Skylaris, P. D. Haynes, A. A. Mostofi, and M. C. Payne, J. Chem. Phys. **122**, 084119 (2005).
 

--- a/ldos_calculations.rst
+++ b/ldos_calculations.rst
@@ -312,10 +312,11 @@ angular momentum channel of each atom group.
 
 Recommended Settings
 --------------------
-The following table provides a set of recommended settings for calculating the PDOS in ONETEP:
+The following table provides a set of recommended settings for 
+calculating the PDOS in ONETEP:
 
 .. list-table::
-   :widths: 8 20 32 20
+   :widths: 8 16 16 20
    :header-rows: 1
 
    * - 
@@ -335,8 +336,8 @@ The following table provides a set of recommended settings for calculating the P
      - 13.0
      - Fully uncontracted spherical waves
 
-These settings were calibrated and tested with platinum nanoparticles, and are a starting 
-point for obtaining reliable PDOS data.
+These settings were calibrated and tested with platinum nanoparticles 
+and should be considered a starting point for your own calculations.
 
 Interpreting Outputs
 --------------------
@@ -350,48 +351,49 @@ input file with 3 ``pdos_groups`` and ``pdos_max_l=2``):
 
       
     ================ Projected Density of States (pDOS) calculation ================
-
-    Constructing AM resolved functions  ...... done
-
+    
+    Constructing AM resolved functions  ... done
+    Writing NGWF plot files in formats: ...  done
+    
     Performing overlap integrals ...  done
-
+    
     Computing pDOS weights ...  done
-
-    All bands spilling parameter =   2.16 %
+    
+    All bands spilling parameter =   2.14 %
     Occupancy-weighted spilling parameter =   0.30 %
-
+    
      => Outputting data for OptaDOS <=
-
+    
     Writing pDOS weights to file "Pt3O.val_pdos_bin" ... done
-
+    
     Writing band gradients to file "Pt3O.val_dome_bin" ... done
-
+    
     Writing Castep output cell file to "Pt3O-out.cell" ... done
-
-     => Computing Gaussian smeared pDOS <=
+    
+      => Computing Gaussian smeared pDOS <= 
     Writing "Pt3O_PDOS.txt" ...  done
-
-     => Computing Occupancy-weighted Gaussian smeared pDOS <=
+    
+      => Computing Occupancy-weighted Gaussian smeared pDOS <= 
     Writing "Pt3O_occ_PDOS.txt" ...  done
-      => Band centres:
-     S band centre of group 1:  -10.784858 eV
-     P band centre of group 1:   -6.380333 eV
-     D band centre of group 1:   -1.992269 eV
-     S band centre of group 2:   -3.492084 eV
-     P band centre of group 2:   -5.494629 eV
-     D band centre of group 2:   -1.992269 eV
-     S band centre of group 3:  -20.033217 eV
-     P band centre of group 3:   -6.607254 eV
+      => Band centres: 
+     S band centre of group 1 from  -24.409 eV upwards:  -10.785237 eV
+     P band centre of group 1 from  -24.409 eV upwards:   -6.380437 eV
+     D band centre of group 1 from  -25.000 eV upwards:   -1.992329 eV
+     S band centre of group 2 from  -24.409 eV upwards:   -3.492322 eV
+     P band centre of group 2 from  -24.409 eV upwards:   -5.494682 eV
+     D band centre of group 2 from  -25.000 eV upwards:   -1.992329 eV
+     S band centre of group 3 from  -24.409 eV upwards:  -20.033099 eV
+     P band centre of group 3 from  -24.409 eV upwards:   -6.607392 eV
       Band centres done. <=
-      => Integrated number of electrons in each AM band:
-     S num electrons of group 1:    3.769061
-     P num electrons of group 1:    5.624284
-     D num electrons of group 1:   26.497454
-     S num electrons of group 2:    2.107330
-     P num electrons of group 2:    1.147080
-     D num electrons of group 2:   26.497454
-     S num electrons of group 3:    1.661731
-     P num electrons of group 3:    4.477204
+      => Integrated number of electrons in each AM band: 
+     S num electrons of group 1 from  -24.409 eV upwards:    3.768881
+     P num electrons of group 1 from  -24.409 eV upwards:    5.624424
+     D num electrons of group 1 from  -25.000 eV upwards:   26.497489
+     S num electrons of group 2 from  -24.409 eV upwards:    2.107161
+     P num electrons of group 2 from  -24.409 eV upwards:    1.147191
+     D num electrons of group 2 from  -25.000 eV upwards:   26.497489
+     S num electrons of group 3 from  -24.409 eV upwards:    1.661719
+     P num electrons of group 3 from  -24.409 eV upwards:    4.477233
       Integrated number of electrons done. <=
     ================================================================================
 
@@ -423,7 +425,9 @@ Finally ONETEP reports the energy and occupancy weighted averages of the
 PDOS, so called-band centres, useful in catalysis (e.g. the value
 “d-band centre” is a very useful decsriptor about the ability of a metal
 surface to bind atomic oxygen and other types of adsorbates) and the
-integrated number of electrons in each component.
+integrated number of electrons in each component. The d-band centre is 
+calculated from a threshold, which by default is -15 eV, but this can be
+adjusted using the ``pdos_d_band_threshold`` keyword.
 
 [Skylaris2005] C.-K. Skylaris, P. D. Haynes, A. A. Mostofi, and M. C. Payne, J. Chem. Phys. **122**, 084119 (2005).
 

--- a/ldos_calculations.rst
+++ b/ldos_calculations.rst
@@ -4,7 +4,8 @@ Calculating the Local/Partial Density of States and Angular Momentum Projected D
 
 :Author: Nicholas D.M. Hine, University of Warwick (originally Imperial College London)
 :Author: Jolyon Aarons, University of Warwick
-
+:Author: Weibo Ng, University of Southampton
+:Date: August 2024 (Updated by Weibo Ng to include recommended parameters).
 :Date: June 2019 (Updated by Jolyon Aarons to add angular momentum PDOS information).
 :Date: Originally written by Nicholas D.M. Hine April 2012.
 
@@ -427,7 +428,8 @@ PDOS, so called-band centres, useful in catalysis (e.g. the value
 surface to bind atomic oxygen and other types of adsorbates) and the
 integrated number of electrons in each component. The d-band centre and
 number of electrons are calculated from a threshold, which by default is
--15 eV, but this can be adjusted using the ``pdos_d_band_threshold`` keyword.
+set to -15 eV, but this can be adjusted with the ``pdos_d_band_threshold``
+keyword.
 
 [Skylaris2005] C.-K. Skylaris, P. D. Haynes, A. A. Mostofi, and M. C. Payne, J. Chem. Phys. **122**, 084119 (2005).
 

--- a/ldos_calculations.rst
+++ b/ldos_calculations.rst
@@ -424,7 +424,7 @@ plotted trivially with xmgrace, or any other plotting tool.
 
 Finally ONETEP reports the energy and occupancy weighted averages of the
 PDOS, so called-band centres, useful in catalysis (e.g. the value
-“d-band centre” is a very useful decsriptor about the ability of a metal
+“d-band centre” is a very useful descriptor about the ability of a metal
 surface to bind atomic oxygen and other types of adsorbates) and the
 integrated number of electrons in each component. The d-band centre and
 number of electrons are calculated from a threshold, which by default is


### PR DESCRIPTION
Edited the LDOS page:
- Added a table for recommended values for PDOS based off Pt nanoparticle calculations.
- Changed the example output (by rerunning QC test 49) to include the changes to the d-band centre code 
- Added a small bit on the new keyword that changes the d-band threshold