### PR TITLE
fix: missing search links in keyword list

### DIFF
--- a/_ext/searchlink.py
+++ b/_ext/searchlink.py
@@ -25,10 +25,7 @@ class SearchLinkRole(SphinxRole):
 
     def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
         """Generate search link from role directive."""
-        if (
-            getattr(self.env.app, "builder", None)
-            and self.env.app.builder.name != "html"
-        ):
+        if "html" not in self.env.app.tags:
             logger.warning(
                 "Search links are only supported in HTML output.",
                 location=self.get_source_info(),


### PR DESCRIPTION
Use a different method of checking for Sphinx HTML output to fix inactive search links in keyword list page.